### PR TITLE
WIP: Integrates with recent files for opened CSV files

### DIFF
--- a/main.js
+++ b/main.js
@@ -551,6 +551,13 @@ function buildMenu() {
           },
         },
         {
+          label: "Open Recent CSV",
+          role: "recentdocuments",
+          submenu: [
+            { label: "Clear Recent Items", role: "clearrecentdocuments" },
+          ],
+        },
+        {
           label: "Open Database…",
           accelerator: "CommandOrControl+D",
           click: async () => {

--- a/main.js
+++ b/main.js
@@ -529,6 +529,7 @@ function buildMenu() {
             }
             let pathToOpen = null;
             for (const filepath of selectedFiles) {
+              app.addRecentDocument(filepath);
               const response = await datasette.apiRequest("/-/open-csv-file", {
                 path: filepath,
               });
@@ -732,4 +733,24 @@ app.whenReady().then(async () => {
 // explicitly with Cmd + Q.
 app.on("window-all-closed", function () {
   if (process.platform !== "darwin") app.quit();
+});
+
+app.on("open-file", async (event, filepath) => {
+  const response = await datasette.apiRequest("/-/open-csv-file", {
+    path: filepath,
+  });
+  const responseJson = await response.json();
+  if (!responseJson.ok) {
+    console.log(responseJson);
+    dialog.showMessageBox({
+      type: "error",
+      message: "Error opening CSV file",
+      detail: responseJson.error,
+    });
+  } else {
+    pathToOpen = responseJson.path;
+  }
+  setTimeout(() => {
+    datasette.openPath(pathToOpen);
+  });
 });


### PR DESCRIPTION
Primitively attempts to address #54.

This is a rather ugly but working solution that implements electron's [recent documents](https://www.electronjs.org/docs/tutorial/recent-documents), storing filepaths of CSV's that are opened using `File -> Open CSV` menu item. 

The list of recent items persists even upon quitting the application, and can be accessed by right-clicking on the dock icon as shown below:

![Screenshot 2021-09-08 at 10 16 05 pm](https://user-images.githubusercontent.com/16018395/132586917-695b3a87-1798-4bc3-8577-6ddd2a07433a.png)

Accessing recent CSVs (and the option to clear the recents list) is available in the file menu as well:

![Screenshot 2021-09-08 at 10 44 04 pm](https://user-images.githubusercontent.com/16018395/132589755-7b93fb67-c75f-4213-bd24-441271fa3c1a.png)


Things to address before this PR is ready:

- [ ] extend this functionality for newly created databases and recently opened databases 
- [ ] refactor to clean up repetition of file opening logic in `main.js` 
