### PR TITLE
Update Electron, Python, Add native Arch support

### DIFF
--- a/download-python.sh
+++ b/download-python.sh
@@ -11,11 +11,3 @@ fi
 filename="cpython-${cpython_version}+${release_date}-${arch}-apple-darwin-install_only.tar.gz"
 
 standalone_python="python/"
-
-if [ ! -d "$standalone_python" ]; then
-    wget https://github.com/indygreg/python-build-standalone/releases/download/${release_date}/${filename}
-    tar -xzvf ${filename}                                                                          
-    rm -rf ${filename}
-    # Now delete the test/ folder, saving about 23MB of disk space
-    rm -rf python/lib/python3.9/test
-fi

--- a/download-python.sh
+++ b/download-python.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
-release_date="20210724"
-filename="cpython-3.9.6-x86_64-apple-darwin-install_only-20210724T1424.tar.gz"
+release_date="20241016"
+cpython_version="3.12.7"
+
+arch=`uname -m`
+# Convert arch to aarch64 to match the build artifact name
+if [ $arch = "arm64" ]; then
+    arch="aarch64"
+fi
+
+filename="cpython-${cpython_version}+${release_date}-${arch}-apple-darwin-install_only.tar.gz"
 
 standalone_python="python/"
 

--- a/download-python.sh
+++ b/download-python.sh
@@ -11,3 +11,9 @@ fi
 filename="cpython-${cpython_version}+${release_date}-${arch}-apple-darwin-install_only.tar.gz"
 
 standalone_python="python/"
+
+if [ ! -d "$standalone_python" ]; then
+    wget https://github.com/indygreg/python-build-standalone/releases/download/${release_date}/${filename}
+    tar -xzvf ${filename}                                                                          
+    rm -rf ${filename}
+fi

--- a/package.json
+++ b/package.json
@@ -71,16 +71,16 @@
   "author": "Simon Willison",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@playwright/test": "^1.25.2",
-    "electron": "^20.1.3",
-    "electron-builder": "^23.3.3",
+    "@playwright/test": "^1.48.2",
+    "@types/electron-prompt": "^1.6.5",
+    "electron": "^33.0.2",
+    "electron-builder": "^25.1.8",
     "electron-notarize": "^1.2.1",
-    "playwright": "^1.25.2"
+    "playwright": "^1.48.2"
   },
   "dependencies": {
     "electron-prompt": "^1.7.0",
-    "electron-request": "^1.8.2",
     "portfinder": "^1.0.32",
-    "update-electron-app": "^2.0.1"
+    "update-electron-app": "^3.0.0"
   }
 }


### PR DESCRIPTION
Hi there! Thanks for making Datasette. This PR does the following: 

- Updates Electron and Node dependencies
- Removes abandoned `electron-request` module dependency, and refactors HTTP request code to use the native Electron `net` module.
- Updates implementation of `update-electron-app` to use modern syntax.
- Updates python3 to 3.12.7 (includes changes to calling python via datasette venv using `python3` to make it minor version agnostic, making future updates easier)
- Adds check to `download-python.sh` to support downloading the architecture native version of python. This should allow for building the Electron app as a Universal Binary, with native arch Python. 